### PR TITLE
left-click on the extension icon to send current browser tab URL to MeTube

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -13,42 +13,43 @@ chrome.runtime.onInstalled.addListener(function() {
     });
 });
 
+function sendVideoUrlToMetubeAndSwitchTab(videoUrl, metubeUrl, tab) {
+    console.log("Sending videoUrl=" + videoUrl + " to metubeUrl=" + metubeUrl);
+    fetch(metubeUrl + "/add", {
+        method: 'POST',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            "quality": "best",
+            "url": videoUrl
+        })
+    }).then(function(res) {
+        if (res.ok === true && res.status === 200) {
+            return res.json();
+        }
+        // todo fix it
+        alert("error :: code " + res.status);
+    }).then(function(result) {
+        if (result.status === "ok") {
+            openTab(metubeUrl, tab);
+        } else {
+            // todo fix it
+            alert("error :: " + json);
+        }
+    }).catch(function(res) {
+        alert("error :: " + res);
+    });
+}
+
 chrome.contextMenus.onClicked.addListener(function(item, tab) {
     chrome.storage.sync.get(['metube'], function(data) {
         if (data === undefined || !data.hasOwnProperty('metube') || data.metube === "") {
             openTab(chrome.runtime.getURL('options.html'), tab);
             return
         }
-
-        fetch(data.metube + "/add", {
-                method: 'POST',
-                headers: {
-                    'Accept': 'application/json',
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    "quality": "best",
-                    "url": item.linkUrl
-                })
-            })
-            .then(function(res) {
-                if (res.ok === true && res.status === 200) {
-                    return res.json();
-                }
-                // todo fix it
-                alert("error :: code " + res.status);
-            })
-            .then(function(result) {
-                if (result.status === "ok") {
-                    openTab(data.metube, tab);
-                } else {
-                    // todo fix it
-                    alert("error :: " + json);
-                }
-            })
-            .catch(function(res) {
-                alert("error :: " + res);
-            })
+        sendVideoUrlToMetubeAndSwitchTab(item.linkUrl, data.metube, tab);
     });
 });
 

--- a/src/background.js
+++ b/src/background.js
@@ -54,13 +54,25 @@ chrome.contextMenus.onClicked.addListener(function(item, tab) {
 });
 
 chrome.action.onClicked.addListener(function(tab) {
-    chrome.storage.sync.get(['metube'], function(data) {
+    chrome.storage.sync.get(['metube', 'sendOnClick'], function(data) {
         if (data === undefined || !data.hasOwnProperty('metube') || data.metube === "") {
             openTab(chrome.runtime.getURL('options.html'), tab);
             return
         }
-
-        openTab(data.metube, tab);
+        chrome.tabs.query({
+            active: true,
+            lastFocusedWindow: true
+        }, function(tabs) {
+            // use this tab to get the youtube video URL
+            let videoUrl = tabs[0].url;
+            if (data.sendOnClick) {
+                sendVideoUrlToMetubeAndSwitchTab(videoUrl, data.metube, tab);
+            }
+            else {
+                console.log("Going to Metube URL...");
+                openTab(data.metube, tab);
+            }
+        });
     });
 });
 

--- a/src/options.html
+++ b/src/options.html
@@ -32,6 +32,8 @@
     <form id="form">
       <h3>Settings</h3>
       <label for="metube">Url of MeTube</label><input type="url" placeholder="http://0.0.0.0:8081/" name="metube" id="metube">
+      <br>
+      <label for="send-on-click">Enable left-click on extension icon to send current page URL to Metube</label><input type="checkbox" name="send-on-click" id="send-on-click">
       <h3>Additional sites</h3>
       <p>Youtube-dl support <a href="https://github.com/ytdl-org/youtube-dl/blob/master/docs/supportedsites.md" target="_blank">many another sites</a> except youtube. You can add mask url's of this sites in textfield bellow but it can affect performance and we have not tested them support</p>
       <p><textarea name="additional" id="additional" placeholder="https://vimeo.com/*

--- a/src/options.js
+++ b/src/options.js
@@ -7,7 +7,9 @@ async function saveOptions() {
 
     let sites = document.getElementById("additional").value;
 
-    chrome.storage.sync.set({ "metube": url, "sites": sites }, function () {
+    let sendOnClick = document.getElementById("send-on-click").checked;
+
+    chrome.storage.sync.set({ "metube": url, "sites": sites, "sendOnClick": sendOnClick}, function () {
         document.getElementById("saved").classList.remove('hidden');
 
         setTimeout(function () {
@@ -18,7 +20,7 @@ async function saveOptions() {
     sites = splitLines(sites);
 
     // todo: fix it
-    // also need make function for check string 
+    // also need make function for check string
     // https://developer.chrome.com/docs/extensions/mv3/match_patterns/
     if(sites.length <= 1){
         return;
@@ -39,15 +41,18 @@ async function saveOptions() {
 }
 
 async function restoreOptions() {
-    chrome.storage.sync.get(['metube', 'sites'], function (data) {
+    chrome.storage.sync.get(['metube', 'sites', 'sendOnClick'], function (data) {
         if (data.metube != undefined) {
-            document.getElementById("metube").value = data.metube;    
+            document.getElementById("metube").value = data.metube;
         }
 
         if (data.sites != undefined) {
-            document.getElementById("additional").value = data.sites;    
+            document.getElementById("additional").value = data.sites;
         }
-        
+        // document.getElementById("send-on-click").checked = true;
+        if (data.sendOnClick) {
+            document.getElementById("send-on-click").checked = true;
+        }
     });
 }
 


### PR DESCRIPTION
These commits add the "left-click on the extension icon to trigger download" behaviour.

This behavior will not enabled by default, but can be enabled by checking a checkbox in the extension's options page. If this option isn't checked, the old behaviour is preserved (i.e. the user is moved to the MeTube page).

This resolves #5 
I'm pretty new to javascript and writing chrome extensions, but I think the code is clean enough to raise this pull request.

After this is merged, please mint a new version and publish it to the Chrome web store @Rpsl 