### PR TITLE
fix: allow custom sites when only one is added

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -29,7 +29,7 @@ async function saveOptions() {
     // todo: fix it
     // also need make function for check string
     // https://developer.chrome.com/docs/extensions/mv3/match_patterns/
-    if(sites.length <= 1){
+    if(!sites.length){
         return;
     }
 


### PR DESCRIPTION
The old code would require the user to add at least 2 sites. 
This will alow the user to add only one rule ex: `https://*/*`